### PR TITLE
agrega return que falta

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const get = function(url) {
     const lib = url.startsWith('https') ? require('https') : require('http');
     const request = lib.get(url, (response) => {
       if (response.statusCode < 200 || response.statusCode > 299) {
-        reject(response);
+        return reject(response);
       }
       resolve(response)
     });
@@ -149,7 +149,7 @@ const get = function(url) {
     const lib = url.startsWith('https') ? require('https') : require('http');
     const request = lib.get(url, (response) => {
       if (response.statusCode < 200 || response.statusCode > 299) {
-        reject(response);
+        return reject(response);
       }
       resolve(response)
     });


### PR DESCRIPTION
Una llamada consecutiva a `resolve` después de invocar a `reject` no dá error (y viceversa) pero el branch conceptualmente pierde relevancia.